### PR TITLE
Initial implementation of the sys command

### DIFF
--- a/crash/cache/sys.py
+++ b/crash/cache/sys.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
+
+import gdb
+from crash.cache import CrashCache
+
+class GetSymbolException(Exception):
+    pass
+
+class GetValueException(Exception):
+    pass
+
+class CrashCacheSys(CrashCache):
+
+    utsname_cache = None
+
+    def init_utsname_cache(self):
+        if self.utsname_cache:
+            return
+
+        try:
+            init_uts_ns = gdb.lookup_global_symbol('init_uts_ns').value()
+            utsname = init_uts_ns['name']
+        except Exception, e:
+            print "Error: Unable to locate utsname: %s" % (e)
+            raise GetSymbolException(e)
+
+        try:
+            self.utsname_cache = dict()
+            self.utsname_cache['nodename'] = utsname['nodename'].string()
+            self.utsname_cache['release'] = utsname['release'].string()
+            self.utsname_cache['version'] = utsname['version'].string()
+            self.utsname_cache['machine'] = utsname['machine'].string()
+        except Exception, e:
+            print "Error: Unable to locate utsname string: %s" % (e)
+            raise GetValueException(e)
+
+    def init_sys_caches(self):
+        self.init_utsname_cache()
+
+    def __init__(self):
+        super(CrashCacheSys, self).__init__()
+
+    def refresh(self):
+        pass
+
+cache = CrashCacheSys()

--- a/crash/cache/sys.py
+++ b/crash/cache/sys.py
@@ -2,6 +2,7 @@
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
 
 import gdb
+import zlib
 from crash.cache import CrashCache
 
 class GetSymbolException(Exception):
@@ -10,9 +11,16 @@ class GetSymbolException(Exception):
 class GetValueException(Exception):
     pass
 
+uchar = gdb.lookup_type('unsigned char')
+ucharp = uchar.pointer()
+
 class CrashCacheSys(CrashCache):
 
     utsname_cache = None
+    ikconfig_raw_cache = None
+
+    def read_buf(self, address, size):
+        return str(gdb.selected_inferior().read_memory(address, size))
 
     def init_utsname_cache(self):
         if self.utsname_cache:
@@ -35,8 +43,45 @@ class CrashCacheSys(CrashCache):
             print "Error: Unable to locate utsname string: %s" % (e)
             raise GetValueException(e)
 
+
+    def init_ikconfig_raw_cache(self):
+        if self.ikconfig_raw_cache:
+            return
+
+        MAGIC_START = 'IKCFG_ST'
+        MAGIC_END = 'IKCFG_ED'
+        GZIP_HEADER_LEN = 10
+
+        kernel_config_data_sym = gdb.lookup_symbol('kernel_config_data', block=None, domain=gdb.SYMBOL_VAR_DOMAIN)[0]
+        kernel_config_data = kernel_config_data_sym.value()
+        # Must cast it to ucharp to do the pointer arithmetic correctly
+        data_addr = kernel_config_data.address.cast(ucharp)
+        data_len = kernel_config_data_sym.type.sizeof
+
+        buf_len = len(MAGIC_START)
+        buf = self.read_buf(data_addr, buf_len)
+        if buf != MAGIC_START:
+            raise IOError("Missing MAGIC_START in kernel_config_data.")
+
+        buf_len = len(MAGIC_END)
+        buf = self.read_buf(data_addr + data_len - buf_len - 1, buf_len)
+        if buf != MAGIC_END:
+            raise IOError("Missing MAGIC_END in kernel_config_data.")
+
+        # Read the compressed data
+        #
+        # FIXME: We skip the gzip header (10 bytes) and decompress
+        #        the data directly using zlib. If we know how to map
+        #        the memory into a file/stream, it would be possible
+        #        to use gzip module.
+        buf_len = data_len - len(MAGIC_START) - len(MAGIC_END) - GZIP_HEADER_LEN
+        buf = self.read_buf(data_addr + len(MAGIC_START) + GZIP_HEADER_LEN, buf_len)
+
+        self.ikconfig_raw_cache = zlib.decompress(buf, -15, buf_len)
+
     def init_sys_caches(self):
         self.init_utsname_cache()
+        self.init_ikconfig_raw_cache()
 
     def __init__(self):
         super(CrashCacheSys, self).__init__()

--- a/crash/commands/sys.py
+++ b/crash/commands/sys.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
+
+import gdb
+from crash.commands import CrashCommand
+from crash.cache import sys
+import argparse
+
+class LogTypeException(Exception):
+    pass
+
+class LogInvalidOption(Exception):
+    pass
+
+class SysCommand(CrashCommand):
+    """system data
+
+NAME
+  sys - system data
+
+SYNOPSIS
+  sys
+
+DESCRIPTION
+  This command displays system-specific data.
+
+EXAMPLES
+  Display essential system information:
+
+    crash> sys
+          KERNEL: vmlinux.4
+        DUMPFILE: lcore.cr.4
+            CPUS: 4
+            DATE: Mon Oct 11 18:48:55 1999
+          UPTIME: 10 days, 14:14:39
+    LOAD AVERAGE: 0.74, 0.23, 0.08
+           TASKS: 77
+        NODENAME: test.mclinux.com
+         RELEASE: 2.2.5-15smp
+         VERSION: #24 SMP Mon Oct 11 17:41:40 CDT 1999
+         MACHINE: i686  (500 MHz)
+          MEMORY: 1 GB
+
+
+    """
+    def __init__(self, name):
+
+        parser = argparse.ArgumentParser(prog=name)
+
+        parser.format_usage = lambda : "sys\n"
+        CrashCommand.__init__(self, name, parser)
+
+    def show_default(self):
+        print "    NODENAME: %s" % (sys.cache.utsname_cache['nodename'])
+        print "     RELEASE: %s" % (sys.cache.utsname_cache['release'])
+        print "     VERSION: %s" % (sys.cache.utsname_cache['version'])
+        print "     MACHINE: %s" % (sys.cache.utsname_cache['machine'])
+
+    def execute(self, args):
+        sys.cache.init_sys_caches()
+        self.show_default()
+
+SysCommand("sys")

--- a/crash/commands/sys.py
+++ b/crash/commands/sys.py
@@ -19,15 +19,19 @@ NAME
   sys - system data
 
 SYNOPSIS
-  sys
+  sys [config]
 
 DESCRIPTION
-  This command displays system-specific data.
+  This command displays system-specific data. If no arguments are entered,
+  the same system data shown during crash invocation is shown.
+
+    config            If the kernel was configured with CONFIG_IKCONFIG, then
+                      dump the in-kernel configuration data.
 
 EXAMPLES
   Display essential system information:
 
-    crash> sys
+    crash> sys config
           KERNEL: vmlinux.4
         DUMPFILE: lcore.cr.4
             CPUS: 4
@@ -47,8 +51,11 @@ EXAMPLES
 
         parser = argparse.ArgumentParser(prog=name)
 
-        parser.format_usage = lambda : "sys\n"
+        parser.add_argument('config', nargs='?')
+
+        parser.format_usage = lambda : "sys [config]\n"
         CrashCommand.__init__(self, name, parser)
+
 
     def show_default(self):
         print "    NODENAME: %s" % (sys.cache.utsname_cache['nodename'])
@@ -56,8 +63,18 @@ EXAMPLES
         print "     VERSION: %s" % (sys.cache.utsname_cache['version'])
         print "     MACHINE: %s" % (sys.cache.utsname_cache['machine'])
 
+    def show_raw_ikconfig(self):
+        print sys.cache.ikconfig_raw_cache
+
     def execute(self, args):
         sys.cache.init_sys_caches()
-        self.show_default()
+
+        if args.config:
+            if args.config == "config":
+                self.show_raw_ikconfig()
+            else:
+                print "Error: unknown option: %s" % (args.config)
+        else:
+            self.show_default()
 
 SysCommand("sys")

--- a/crash/commands/sys.py
+++ b/crash/commands/sys.py
@@ -58,6 +58,7 @@ EXAMPLES
 
 
     def show_default(self):
+        print "      UPTIME: %s" % (sys.cache.kernel_cache['uptime'])
         print "    NODENAME: %s" % (sys.cache.utsname_cache['nodename'])
         print "     RELEASE: %s" % (sys.cache.utsname_cache['release'])
         print "     VERSION: %s" % (sys.cache.utsname_cache['version'])


### PR DESCRIPTION
Hi Jeff,

this pull request adds an initial implementation of the sys (pysys) command.
It shows "only" 6 things at the moment:

It shows 5 values when called without any parameter:

(gdb) pysys
      UPTIME: 00:03:18
    NODENAME: dhcp75
     RELEASE: 3.12.60-52.49-default
     VERSION: #1 SMP Thu Jun 16 06:31:14 UTC 2016 (427261f)
     MACHINE: x86_64

It shows raw kernel config when called with the "config" parameter:

(gdb) pysys config
# Automatically generated file; DO NOT EDIT.
# Linux/x86_64 3.12.60 Kernel Configuration
# 

CONFIG_64BIT=y
CONFIG_X86_64=y
CONFIG_X86=y
...

IMHO, the more interesting thing is that it reads /proc/config.gz from
the crash dump and parse it. Plus it reads few more values. They all are
put into several caches under crash/cache/sys.py. I guess that they will
be useful for many other commands.

IMPORTANT:

First, this is my first "real" hacking in python. I am sure that many things
might be done a better way. Especially, I am not sure about error
handling.

Second, I tried to design it according to the other files and also according
to the crash tool. I am sure that there might be a better design. Especially,
I am not sure about the hierarchy and handling of the caches.

All in all, feel free to reject this pull request and suggest changes. I am
prepared to rework it completely. I am happy that it works as it works.
But I will be even more happy if the design is well suited for the future
development.

FINAL NOTE:

This is my first pull request from github. I hope that I did not screw it
up too much.

Best Regards,
Petr
