### PR TITLE
cras.commands.ps: Allow specifying filtering criteria for pyps

### DIFF
--- a/crash/cache/sysinfo.py
+++ b/crash/cache/sysinfo.py
@@ -145,7 +145,7 @@ class CrashCacheSys(CrashCache):
         buf = ""
 
         for lavg in loadavg:
-            a = int(lavg) + (FIXED_1/200)
+            a = int(lavg) + (FIXED_1//200)
             b = a >> FSHIFT
             c = ((a & (FIXED_1-1)) * 100) >> FSHIFT
             buf += "%d.%02d " % (b,c)

--- a/crash/cache/sysinfo.py
+++ b/crash/cache/sysinfo.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
 
-from __future__ import absolute_import
 import gdb
 import re
 import zlib

--- a/crash/commands/dmesg.py
+++ b/crash/commands/dmesg.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
 
-from __future__ import absolute_import
 import gdb
 from crash.commands import CrashCommand
 from crash.types.util import safe_get_symbol_value as get_value

--- a/crash/commands/kmem.py
+++ b/crash/commands/kmem.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
 
-from __future__ import absolute_import
 import gdb
 import crash
 from crash.commands import CrashCommand

--- a/crash/commands/ps.py
+++ b/crash/commands/ps.py
@@ -7,6 +7,7 @@ import argparse
 from crash.commands import CrashCommand
 from crash.types.task import LinuxTask
 import sys
+import re
 
 if sys.version_info.major >= 3:
     long = int
@@ -525,6 +526,22 @@ EXAMPLES
                           task_struct['comm'].string(),
                           "]", int(task.is_kernel_task()))))
 
+    def is_requested(self, args, task):
+        #match by pid
+        if str(task.task_struct['pid']) in args:
+            return True
+        #match by task_struct addr, omitting leadin '0x'
+        elif str(task.task_struct.address)[2:] in args:
+            return True
+        #match by regex
+        else:
+            task_comm = task.task_struct['comm'].string()
+            for regex in args:
+                if re.match(regex, task_comm) is not None:
+                    return True
+
+        return False
+
     def execute(self, argv):
         sort_by_pid = lambda x: x.info.task_struct['pid']
         sort_by_last_run = lambda x: -x.info.last_run()
@@ -544,18 +561,21 @@ EXAMPLES
                 width = 16
             print(self.header_template.format(width, col4name))
 
-        if not argv.args:
-            for thread in sorted(gdb.selected_inferior().threads(), key=sort_by):
-                task = thread.info
-                if task:
-                    if argv.k and not task.is_kernel_task():
-                        continue
-                    if argv.u and task.is_kernel_task():
-                        continue
 
-                    # Only show thread group leaders
-#                    if argv.G and task.pid != int(task.task_struct['tgid']):
+        for thread in sorted(gdb.selected_inferior().threads(), key=sort_by):
+            task = thread.info
+            if task:
+                if argv.k and not task.is_kernel_task():
+                    continue
+                if argv.u and task.is_kernel_task():
+                    continue
 
-                    task.update_mem_usage()
-                    self.print_one(argv, thread)
+                # Only show thread group leaders
+#               if argv.G and task.pid != int(task.task_struct['tgid']):
+
+                task.update_mem_usage()
+                if argv.args and not self.is_requested(argv.args, task):
+                    continue
+                self.print_one(argv, thread)
+
 PSCommand()

--- a/crash/commands/ps.py
+++ b/crash/commands/ps.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
 
-from __future__ import absolute_import
 import gdb
 import argparse
 from crash.commands import CrashCommand

--- a/crash/commands/pystruct.py
+++ b/crash/commands/pystruct.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 # vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
 
-from __future__ import absolute_import
 import gdb
 import argparse
 from crash.commands import CrashCommand

--- a/crash/commands/pysys.py
+++ b/crash/commands/pysys.py
@@ -3,7 +3,7 @@
 
 import gdb
 from crash.commands import CrashCommand
-from crash.cache import sys
+from crash.cache import sysinfo
 import argparse
 
 class LogTypeException(Exception):
@@ -58,18 +58,18 @@ EXAMPLES
 
 
     def show_default(self):
-        print("      UPTIME: %s" % (sys.cache.kernel_cache['uptime']))
-        print("LOAD AVERAGE: %s" % (sys.cache.kernel_cache['loadavg']))
-        print("    NODENAME: %s" % (sys.cache.utsname_cache['nodename']))
-        print("     RELEASE: %s" % (sys.cache.utsname_cache['release']))
-        print("     VERSION: %s" % (sys.cache.utsname_cache['version']))
-        print("     MACHINE: %s" % (sys.cache.utsname_cache['machine']))
+        print("      UPTIME: %s" % (sysinfo.cache.kernel_cache['uptime']))
+        print("LOAD AVERAGE: %s" % (sysinfo.cache.kernel_cache['loadavg']))
+        print("    NODENAME: %s" % (sysinfo.cache.utsname_cache['nodename']))
+        print("     RELEASE: %s" % (sysinfo.cache.utsname_cache['release']))
+        print("     VERSION: %s" % (sysinfo.cache.utsname_cache['version']))
+        print("     MACHINE: %s" % (sysinfo.cache.utsname_cache['machine']))
 
     def show_raw_ikconfig(self):
-        print(sys.cache.ikconfig_raw_cache)
+        print(sysinfo.cache.ikconfig_raw_cache)
 
     def execute(self, args):
-        sys.cache.init_sys_caches()
+        sysinfo.cache.init_sys_caches()
 
         if args.config:
             if args.config == "config":


### PR DESCRIPTION
This change allows to invoke pyps such as: 'pyps 3789 ffff880134eda600 ssh*'

Which outputs:

PID    PPID  CPU       TASK        ST  %MEM     VSZ    RSS  COMM
3062       1    0  ffff880136d54400 IN   0.0   53764   1160  sshd
3083       1    5  ffff880134eda600 IN   0.0  133696    932  nscd
3434    3062    5  ffff880134fc6200 IN   0.0   79788   3588  sshd
3474    3062    5  ffff880137588640 IN   0.0   79788   3588  sshd
3789       2    3  ffff8801341dc600 IN   0.0       0      0  [xfsbufd/vdb]

It will do the matching for pid first, then task_struct address and finally
a regex on task_struct->comm