### PR TITLE
kdump: replace vtop_init() with setting the 'ostype' attribute

### DIFF
--- a/crash/kdump/target.py
+++ b/crash/kdump/target.py
@@ -33,7 +33,7 @@ class Target(gdb.Target):
         self.kdump = kdumpfile(fil)
         self.setup_arch()
         self.kdump.symbol_func = symbol_func
-        self.kdump.vtop_init()
+        self.kdump.attr['addrxlat.ostype'] = 'linux'
         super(Target, self).__init__()
         gdb.execute('set print thread-events 0')
         self.setup_tasks()


### PR DESCRIPTION
This in fact exactly what the vtop_init() method does now. This reflects
a change in the underlying libkdumpfile concepts. The function has already
been removed from libkdumpfile API and is about to be removed from the
Python API as well.

Signed-off-by: Petr Tesarik <ptesarik@suse.com>