### PR TITLE
Fix a braino in BadTaskError.__init__()

### DIFF
--- a/crash/types/task.py
+++ b/crash/types/task.py
@@ -110,7 +110,7 @@ class BadTaskError(TypeError):
             typedesc = task.type
         else:
             typedesc = type(task)
-        self(BadTaskError, task).__init__(msgtemplate.format(typedesc))
+        super(BadTaskError, self).__init__(self.msgtemplate.format(typedesc))
 
 @delayed_init
 class LinuxTask(object):


### PR DESCRIPTION
Instantiation of BadTaskError fails because of this code (most likely
written too late at night).

Signed-off-by: Petr Tesarik <ptesarik@suse.com>