### PR TITLE
fix mount -f error caused by incorrect reference to mnt_flags field

### DIFF
--- a/crash/subsystem/filesystem/mount.py
+++ b/crash/subsystem/filesystem/mount.py
@@ -76,7 +76,7 @@ class Mount(CrashBaseClass):
     @export
     @classmethod
     def mount_flags(cls, mnt, show_hidden=False):
-        flags = long(mnt['mnt_flags'])
+        flags = long(mnt['mnt']['mnt_flags'])
 
         if flags & MNT_READONLY:
             flagstr = "ro"


### PR DESCRIPTION
in function mount_flags