### PR TITLE
tests: Fix expected error in tests_target.py

### DIFF
--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -15,7 +15,7 @@ class TestUtil(unittest.TestCase):
         self.do_real_tests = os.path.exists("tests/vmcore")
 
     def test_bad_file(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             x = Target("/does/not/exist")
 
     def test_real_open_with_no_kernel(self):


### PR DESCRIPTION
Since commit 1b04cc4 "crash.session: move most of setup to crash.kernel",
gdb.Target throws a TypeError instead of a RuntimeError in __init__ when the
vmcore argument is illegal.

Update the corresponding test in test_target.py accordingly.