### PR TITLE
python-crash changes to work with OpenEmbedded

### DIFF
--- a/crash/types/page.py
+++ b/crash/types/page.py
@@ -141,7 +141,7 @@ class Page:
         # TODO: handle kernels with no space for nodes in page flags
         try:
             cls.NODES_WIDTH = int(config['NODES_SHIFT'])
-        except (KeyError, DelayedAttributeError):
+        except (KeyError, TypeError, DelayedAttributeError):
             # XXX
             print("Unable to determine NODES_SHIFT from config, trying 8")
             cls.NODES_WIDTH = 8

--- a/crash/types/task.py
+++ b/crash/types/task.py
@@ -588,6 +588,9 @@ class LinuxTask:
     def _last_run__last_arrival(self) -> int:
         return int(self.task_struct['sched_info']['last_arrival'])
 
+    def _last_run__return_zero(self) -> int:
+        return 0
+
     @classmethod
     def _pick_last_run(cls) -> None:
         fields = types.task_struct_type.keys()
@@ -601,7 +604,8 @@ class LinuxTask:
         elif 'timestamp' in fields:
             cls._get_last_run = cls._last_run__timestamp
         else:
-            raise RuntimeError("No method to retrieve last run from task found.")
+            cls._get_last_run = cls._last_run__return_zero
+            print("No method to retrieve last run from task found. Consider enabling CONFIG_TASKSTATS and CONFIG_TASK_DELAY_ACCT to activate CONFIG_SCHED_INFO kernel config")
 
     def last_run(self) -> int:
         """


### PR DESCRIPTION
Hi Jeff,

I have been working on integrating python-crash tool with OpenEmbedded
distro. I have created meta-krash [1] OpenEmbedded layer that primarily
includes crash-python tool. During my integration I ran into several
issues. For example, OpenEmbedded kernel does not enable CONFIG_NUMA, or
CONFIG_SCHED_INFO and uses CONFIG_SLUB (vs CONFIG_SLAB). To deal with the
differences I have added a few patches.

Although OpenEmbedded layer allows local changes for upstream projects
it would be great if you could look at my changes and possibly merge
them. If you have any comments or remarks it would be greatly appreciated.

Thanks,
Alexander

[1] https://github.com/AlexanderKamensky/meta-kcrash