### PR TITLE
Printk lockless ringbuffer

### DIFF
--- a/crash/commands/dmesg.py
+++ b/crash/commands/dmesg.py
@@ -148,6 +148,7 @@ import gdb
 from crash.commands import Command, ArgumentParser, CommandError
 from crash.exceptions import DelayedAttributeError
 from crash.subsystem.printk import LogTypeException, LogInvalidOption
+from crash.subsystem.printk.lockless_ringbuffer import lockless_rb_show
 from crash.subsystem.printk.structured_ringbuffer import structured_rb_show
 from crash.subsystem.printk.plain_ringbuffer import plain_rb_show
 
@@ -164,6 +165,12 @@ class LogCommand(Command):
         Command.__init__(self, name, parser)
 
     def execute(self, args: argparse.Namespace) -> None:
+        try:
+            lockless_rb_show(args)
+            return
+        except LogTypeException:
+            pass
+
         try:
             structured_rb_show(args)
             return

--- a/crash/commands/dmesg.py
+++ b/crash/commands/dmesg.py
@@ -141,24 +141,15 @@ Display the same message text as above, with appended dictionary data:
 
 from typing import Dict, Iterable, Any
 
-import re
 import argparse
 
 import gdb
 
 from crash.commands import Command, ArgumentParser, CommandError
 from crash.exceptions import DelayedAttributeError
-from crash.util.symbols import Types, Symvals
-
-types = Types(['struct printk_log *', 'char *'])
-symvals = Symvals(['log_buf', 'log_buf_len', 'log_first_idx', 'log_next_idx',
-                   'clear_seq', 'log_first_seq', 'log_next_seq'])
-
-class LogTypeException(Exception):
-    pass
-
-class LogInvalidOption(Exception):
-    pass
+from crash.subsystem.printk import LogTypeException, LogInvalidOption
+from crash.subsystem.printk.structured_ringbuffer import structured_rb_show
+from crash.subsystem.printk.plain_ringbuffer import plain_rb_show
 
 class LogCommand(Command):
     """dump system message buffer"""
@@ -172,111 +163,15 @@ class LogCommand(Command):
 
         Command.__init__(self, name, parser)
 
-    @classmethod
-    def filter_unstructured_log(cls, log: str, args: argparse.Namespace) -> str:
-        lines = log.split('\n')
-        if not args.m:
-            newlog = []
-            for line in lines:
-                if not args.m:
-                    line = re.sub(r'^<[0-9]+>', '', line)
-                if args.t:
-                    line = re.sub(r'^\[[0-9\. ]+\] ', '', line)
-                newlog.append(line)
-            lines = newlog
-
-        return '\n'.join(lines)
-
-    def log_from_idx(self, logbuf: gdb.Value, idx: int) -> Dict:
-        msg = (logbuf + idx).cast(types.printk_log_p_type)
-
-        try:
-            textval = (msg.cast(types.char_p_type) +
-                       types.printk_log_p_type.target().sizeof)
-            text = textval.string(length=int(msg['text_len']))
-        except UnicodeDecodeError as e:
-            print(e)
-
-        textlen = int(msg['text_len'])
-        dictlen = int(msg['dict_len'])
-
-        dictval = (msg.cast(types.char_p_type) +
-                   types.printk_log_p_type.target().sizeof + textlen)
-        dict = dictval.string(length=dictlen)
-
-        msglen = int(msg['len'])
-
-        # A zero-length message means we wrap back to the beginning
-        if msglen == 0:
-            nextidx = 0
-        else:
-            nextidx = idx + msglen
-
-        msgdict = {
-            'text' : text[0:textlen],
-            'timestamp' : int(msg['ts_nsec']),
-            'level' : int(msg['level']),
-            'next' : nextidx,
-            'dict' : dict[0:dictlen],
-        }
-
-        return msgdict
-
-    def get_log_msgs(self) -> Iterable[Dict[str, Any]]:
-        try:
-            idx = symvals.log_first_idx
-        except DelayedAttributeError:
-            raise LogTypeException('not structured log') from None
-
-        if symvals.clear_seq < symvals.log_first_seq:
-            # mypy seems to think the preceding clear_seq is fine but this
-            # one isn't.  Derp.
-            symvals.clear_seq = symvals.log_first_seq # type: ignore
-
-        seq = symvals.clear_seq
-        idx = symvals.log_first_idx
-
-        while seq < symvals.log_next_seq:
-            msg = self.log_from_idx(symvals.log_buf, idx)
-            seq += 1
-            idx = msg['next']
-            yield msg
-
-    def handle_structured_log(self, args: argparse.Namespace) -> None:
-        for msg in self.get_log_msgs():
-            timestamp = ''
-            if not args.t:
-                usecs = int(msg['timestamp'])
-                timestamp = ('[{:5d}.{:06d}] '
-                             .format(usecs // 1000000000,
-                                     (usecs % 1000000000) // 1000))
-            level = ''
-            if args.m:
-                level = '<{:d}>'.format(msg['level'])
-
-            for line in msg['text'].split('\n'):
-                print('{}{}{}'.format(level, timestamp, line))
-
-            if (args.d and msg['dict']):
-                for dict in msg['dict'].split('\0'):
-                    print('  {}'.format(dict))
-
-    def handle_logbuf(self, args: argparse.Namespace) -> None:
-        if symvals.log_buf_len and symvals.log_buf:
-            if args.d:
-                raise LogInvalidOption("Unstructured logs don't offer key/value pair support")
-
-            print(self.filter_unstructured_log(symvals.log_buf.string('utf-8', 'replace'), args))
-
     def execute(self, args: argparse.Namespace) -> None:
         try:
-            self.handle_structured_log(args)
+            structured_rb_show(args)
             return
         except LogTypeException:
             pass
 
         try:
-            self.handle_logbuf(args)
+            plain_rb_show(args)
             return
         except LogTypeException:
             pass

--- a/crash/subsystem/printk/__init__.py
+++ b/crash/subsystem/printk/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
+
+import gdb
+
+from crash.exceptions import DelayedAttributeError
+
+class LogTypeException(Exception):
+    pass
+
+class LogInvalidOption(Exception):
+    pass

--- a/crash/subsystem/printk/lockless_ringbuffer.py
+++ b/crash/subsystem/printk/lockless_ringbuffer.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+# vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
+
+from typing import Dict, Iterable, Any
+
+import argparse
+import sys
+import gdb
+
+from crash.util.symbols import Types, Symvals
+from crash.exceptions import DelayedAttributeError
+from crash.subsystem.printk import LogTypeException, LogInvalidOption
+
+types = Types(['struct printk_info *',
+               'struct prb_desc *',
+               'struct prb_data_block *',
+               'unsigned long',
+               'char *'])
+
+symvals = Symvals(['prb', 'clear_seq'])
+
+# TODO: put to separate type
+def atomic_long_read(val: gdb.Value) -> int:
+    return int(val["counter"])
+
+def read_null_end_string(buf: gdb.Value) -> str:
+    ''' Read null-terminated string from a given buffer. '''
+    text = buf.string(encoding='utf8', errors='replace')
+    return text.partition('\0')[0]
+
+class LogConsistencyException(Exception):
+    pass
+
+class DevPrintkInfo:
+    ''' Kernel struct dev_printk_info '''
+    subsystem: str
+    device: str
+
+    def __init__(self, info: gdb.Value) -> None:
+        self.subsystem = read_null_end_string(info['subsystem'])
+        self.device = read_null_end_string(info['device'])
+
+
+class PrintkInfo:
+    ''' Kernel struct printk_info '''
+    seq: int			# sequence number
+    ts_nsec: int		# timestamp in nanoseconds
+    text_len: int	# length of text message
+    facility: int	# syslog facility
+    flags: int		# internal record flags
+    level: int		# syslog level
+    caller_id: int	# thread id or processor id
+    dev_info: DevPrintkInfo
+
+    def __init__(self, info: gdb.Value) -> None:
+        self.seq = int(info['seq'])
+        self.ts_nsec = int(info['ts_nsec'])
+        self.text_len = int(info['text_len'])
+        self.facility = int(info['facility'])
+        self.flags = int(info['flags'])
+        self.level = int(info['level'])
+        self.caller_id = int(info['caller_id'])
+        self.dev_info = DevPrintkInfo(info['dev_info'])
+
+
+class PrbDataBlkLPos:
+    ''' Kernel struct prb_data_blk_pos '''
+    begin: int
+    next: int
+
+    def __init__(self, blk_lpos: gdb.Value) -> None:
+        self.begin = int(blk_lpos['begin'])
+        self.next = int(blk_lpos['next'])
+
+
+class PrbDesc:
+    ''' Kernel struct prb_desc '''
+    state_var: int
+    text_blk_lpos: PrbDataBlkLPos
+    sv_shift: int
+    sv_mask: int
+
+    def __init__(self, desc: gdb.Value) -> None:
+        self.state_var = atomic_long_read(desc['state_var'])
+        self.text_blk_lpos = PrbDataBlkLPos(desc['text_blk_lpos'])
+
+        sv_bits = types.unsigned_long_type.sizeof * 8
+        self.sv_shift = sv_bits - 2
+        self.sv_mask = 0x3 << self.sv_shift
+
+    def desc_state(self) -> int:
+        ''' Return state of the descriptor '''
+        return (self.state_var & self.sv_mask) >> self.sv_shift
+
+    def is_finalized(self):
+        ''' Finalized desriptor points to a valid (deta) message '''
+        return self.desc_state() == 0x2
+
+    def is_reusable(self):
+        '''
+        Reusable descriptor still has a valid sequence number
+        but the data are gone.
+        '''
+        return self.desc_state() == 0x3
+
+
+class PrbDataBlock:
+    ''' Kernel struct prb_data_block '''
+    id: int
+    data: gdb.Value
+
+    def __init__(self, dr: gdb.Value) -> None:
+        self.id = int(dr['id'])
+        self.data = dr['data']
+
+class PrbDataRing:
+    ''' Kernel struct prb_data_ring '''
+    size_bits: int
+    data: gdb.Value
+    lpos_mask: int
+
+    def __init__(self, dr: gdb.Value) -> None:
+        self.size_bits = int(dr['size_bits'])
+        self.data = dr['data']
+
+        self.lpos_mask = (1 << self.size_bits) - 1
+
+    def get_data_block(self, blk_lpos: PrbDataBlkLPos) -> PrbDataBlock:
+        ''' Return PrbDataBlock for the given blk_lpos '''
+        begin_idx = blk_lpos.begin & self.lpos_mask
+        blk_p = self.data.cast(types.char_p_type) + begin_idx
+        return PrbDataBlock(blk_p.cast(types.prb_data_block_p_type))
+
+    def get_text(self, blk_lpos: PrbDataBlkLPos, len: int) -> str:
+        ''' return string stored at the given blk_lpos '''
+        data_block = self.get_data_block(blk_lpos)
+        return data_block.data.string(length=len)
+
+
+class PrbDescRing:
+    ''' Kernel struct prb_desc_ring '''
+    count_bits: int
+    descs: gdb.Value
+    infos: gdb.Value
+    head_id: int
+    tail_id: int
+    mask_id: int
+
+    def __init__(self, dr: gdb.Value) -> None:
+        self.count_bits = int(dr['count_bits'])
+        self.descs = dr['descs']
+        self.infos = dr['infos']
+        self.head_id = atomic_long_read(dr['head_id'])
+        self.tail_id = atomic_long_read(dr['tail_id'])
+        self.mask_id = (1 << self.count_bits) - 1
+
+    def get_idx(self, id: int) -> int:
+        ''' Return index to the desc ring for the given id '''
+        return id & self.mask_id
+
+    def get_desc(self, id: int) -> PrbDesc:
+        ''' Return prb_desc structure for the given id '''
+        idx = self.get_idx(id)
+        desc_p = (self.descs.cast(types.char_p_type) +
+                  types.prb_desc_p_type.target().sizeof * idx)
+        return PrbDesc(desc_p.cast(types.prb_desc_p_type))
+
+    def get_info(self, id: int) -> PrintkInfo:
+        ''' return printk_info structure for the given id '''
+        idx = self.get_idx(id)
+        info_p = (self.infos.cast(types.char_p_type) +
+                  types.printk_info_p_type.target().sizeof * idx)
+        return PrintkInfo(info_p.cast(types.printk_info_p_type))
+
+
+class PrbRingBuffer:
+    ''' Kernel struct prb_ring_buffer '''
+    desc_ring: PrbDescRing
+    data_ring: PrbDataRing
+
+    def __init__(self, prb: gdb.Value) -> None:
+        self.desc_ring = PrbDescRing(gdb.Value(prb['desc_ring']))
+        self.data_ring = PrbDataRing(gdb.Value(prb['text_data_ring']))
+
+    def is_valid_desc(self, desc: PrbDesc, info: PrintkInfo, seq: int) -> bool:
+        ''' Does the descritor constains consistent values? '''
+        if (not (desc.is_finalized() or desc.is_reusable())):
+            return False
+        # Must match the expected seq number. Otherwise is being updated.
+        return (info.seq == seq)
+
+    def first_seq(self) -> int:
+        '''
+        Get sequence number of the tail entry.
+        '''
+
+        # The lockless algorithm guarantees that the tail entry
+        # always points to a descriptor in finalized or reusable state.
+        # The only exception is when the tail is being moved
+        # to the next entry, see prb_first_seq() in printk_ringbuffer.c
+        #
+        # As a result, the valid sequence number should be either in tail_id
+        # or tail_id + 1 entry.
+        for i in range(0, 1):
+            id = self.desc_ring.tail_id + i
+            desc = self.desc_ring.get_desc(id)
+
+            if (desc.is_finalized() or desc.is_reusable()):
+                info = self.desc_ring.get_info(id)
+                return info.seq
+
+        # Something went wrong. Do not continue with an invalid sequence number.
+        raise LogConsistencyException('Can not find valid info in the tail descriptor')
+
+    def show_msg(self, desc: PrbDesc, info: PrintkInfo,
+                 args: argparse.Namespace) -> None:
+        '''
+        Show the message for the gived descriptor, printk info.
+        The output is mofified by pylog parameters.
+        '''
+
+        timestamp = ''
+        if not args.t:
+            timestamp = ('[{:5d}.{:06d}] '
+                         .format(info.ts_nsec // 1000000000,
+                                 (info.ts_nsec % 1000000000) // 1000))
+
+        level = ''
+        if args.m:
+            level = '<{:d}>'.format(info.level)
+
+        text = self.data_ring.get_text(desc.text_blk_lpos, info.text_len)
+        print('{}{}{}'.format(level,timestamp,text))
+
+        if (args.d):
+            # Only two dev_info values are supported at the moment
+            if (len(info.dev_info.subsystem)):
+                print('  SUBSYSTEM={}'.format(info.dev_info.subsystem))
+            if (len(info.dev_info.device)):
+                print('  DEVICE={}'.format(info.dev_info.device))
+
+    def show_log(self, args: argparse.Namespace) -> None:
+        """ Show the entire log """
+        seq = self.first_seq()
+
+        # Iterate over all entries with valid sequence number
+        while True:
+            desc = self.desc_ring.get_desc(seq)
+            info = self.desc_ring.get_info(seq)
+            if (not self.is_valid_desc(desc, info, seq)):
+                break
+
+            seq += 1
+
+            # Sequence numbers are stored in separate ring buffer.
+            # The descriptor ring might include valid sequence numbers
+            # but the data might already be replaced.
+            if (desc.is_reusable()):
+                continue
+
+            self.show_msg(desc, info, args)
+        return
+
+def lockless_rb_show(args: argparse.Namespace) -> None:
+    """
+    Try to show printk log stored in the lockless ringbuffer
+
+    This type of ringbuffer has replaced the structured ring buffer
+    in kernel-5.10.
+
+    Raises:
+         LogTypeException: The log is not in the lockless ringbuffer.
+    """
+
+    try:
+        test = symvals.prb
+    except DelayedAttributeError:
+        raise LogTypeException('not lockless log') from None
+
+    prb = PrbRingBuffer(symvals.prb)
+
+    prb.show_log(args)

--- a/crash/subsystem/printk/plain_ringbuffer.py
+++ b/crash/subsystem/printk/plain_ringbuffer.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
+
+import argparse
+import re
+
+import gdb
+
+from crash.util.symbols import Types, Symvals
+from crash.subsystem.printk import LogTypeException, LogInvalidOption
+
+types = Types(['char *'])
+symvals = Symvals(['log_buf', 'log_buf_len'])
+
+def plain_rb_filter(log: str, args: argparse.Namespace) -> str:
+    lines = log.split('\n')
+    if not args.m:
+        newlog = []
+        for line in lines:
+            if not args.m:
+                line = re.sub(r'^<[0-9]+>', '', line)
+            if args.t:
+                line = re.sub(r'^\[[0-9\. ]+\] ', '', line)
+            newlog.append(line)
+        lines = newlog
+
+    return '\n'.join(lines)
+
+def plain_rb_show(args: argparse.Namespace) -> None:
+    if symvals.log_buf_len and symvals.log_buf:
+        if args.d:
+            raise LogInvalidOption("Unstructured logs don't offer key/value pair support")
+
+        print(plain_rb_filter(symvals.log_buf.string('utf-8', 'replace'), args))

--- a/crash/subsystem/printk/structured_ringbuffer.py
+++ b/crash/subsystem/printk/structured_ringbuffer.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# vim:set shiftwidth=4 softtabstop=4 expandtab textwidth=79:
+
+from typing import Dict, Iterable, Any
+
+import argparse
+
+import gdb
+
+from crash.util.symbols import Types, Symvals
+from crash.exceptions import DelayedAttributeError
+from crash.subsystem.printk import LogTypeException, LogInvalidOption
+
+types = Types(['struct printk_log *', 'char *'])
+symvals = Symvals(['log_buf', 'log_buf_len', 'log_first_idx', 'log_next_idx',
+                   'clear_seq', 'log_first_seq', 'log_next_seq'])
+
+
+def log_from_idx(logbuf: gdb.Value, idx: int) -> Dict:
+    msg = (logbuf + idx).cast(types.printk_log_p_type)
+
+    try:
+        textval = (msg.cast(types.char_p_type) +
+                   types.printk_log_p_type.target().sizeof)
+        text = textval.string(length=int(msg['text_len']))
+    except UnicodeDecodeError as e:
+        print(e)
+
+    textlen = int(msg['text_len'])
+    dictlen = int(msg['dict_len'])
+
+    dictval = (msg.cast(types.char_p_type) +
+               types.printk_log_p_type.target().sizeof + textlen)
+    dict = dictval.string(length=dictlen)
+
+    msglen = int(msg['len'])
+
+    # A zero-length message means we wrap back to the beginning
+    if msglen == 0:
+        nextidx = 0
+    else:
+        nextidx = idx + msglen
+
+    msgdict = {
+        'text' : text[0:textlen],
+        'timestamp' : int(msg['ts_nsec']),
+        'level' : int(msg['level']),
+        'next' : nextidx,
+        'dict' : dict[0:dictlen],
+    }
+
+    return msgdict
+
+def get_log_msgs() -> Iterable[Dict[str, Any]]:
+    try:
+        idx = symvals.log_first_idx
+    except DelayedAttributeError:
+        raise LogTypeException('not structured log') from None
+
+    if symvals.clear_seq < symvals.log_first_seq:
+        # mypy seems to think the preceding clear_seq is fine but this
+        # one isn't.  Derp.
+        symvals.clear_seq = symvals.log_first_seq # type: ignore
+
+    seq = symvals.clear_seq
+    idx = symvals.log_first_idx
+
+    while seq < symvals.log_next_seq:
+        msg = log_from_idx(symvals.log_buf, idx)
+        seq += 1
+        idx = msg['next']
+        yield msg
+
+def structured_rb_show(args: argparse.Namespace) -> None:
+    for msg in get_log_msgs():
+        timestamp = ''
+        if not args.t:
+            usecs = int(msg['timestamp'])
+            timestamp = ('[{:5d}.{:06d}] '
+                         .format(usecs // 1000000000,
+                                 (usecs % 1000000000) // 1000))
+
+        level = ''
+        if args.m:
+            level = '<{:d}>'.format(msg['level'])
+
+        for line in msg['text'].split('\n'):
+            print('{}{}{}'.format(level, timestamp, line))
+
+        if (args.d and msg['dict']):
+            for dict in msg['dict'].split('\0'):
+                print('  {}'.format(dict))


### PR DESCRIPTION
Hello Jeff,

please, push this branch. It adds support to read printk log from the lockless
ringbuffer that has replaced the structured one in kernel-5.10.

There are two preparatory commits. One fixes a small bug. The other
splits the existing code so that each ring buffer type is implemented
separately.

I tested it with 4.12 and 5.11 kernel. Both structured and lockless ringbuffers
are handled correctly.

I was not able to test the plain one because pycrash was not able to load
crashdump from kernel-3.0 at all.

Best Regards,
Petr